### PR TITLE
Add sticker icons to PDP based on special 'stickers' category tree.

### DIFF
--- a/templates/components/merch/stickers.html
+++ b/templates/components/merch/stickers.html
@@ -1,0 +1,27 @@
+<style>
+.product-stickers {
+    position: absolute;
+    right: 2rem;
+    top: 2rem;
+    display: flex;
+    flex-direction: row;
+}
+.product-stickers__sticker {
+    width: 64px;
+    height: auto;
+}
+</style>
+{{!--
+    We can either use "categories" (built-in variabel) or result from gql_categories frontmatter,
+    i.e. "gql.data.site.product.categories.edges". Using categories output from gql makes it easier
+    to use the `has` helper to filter on '/stickers/' path.
+--}}
+<div class="product-stickers">
+    {{#each gql_categories}}
+        {{#has node.path "/stickers/"}}
+            <div class="product-stickers__sticker">
+                <img src="{{node.defaultImage.url}}" alt="{{node.name}} icon" data-sticker-id="{{node.entityId}}">
+            </div>
+        {{/has}}
+    {{/each}}
+</div>

--- a/templates/components/products/product-view.html
+++ b/templates/components/products/product-view.html
@@ -63,6 +63,7 @@
                     </a>
                 {{/if}}
             </div>
+            {{> components/merch/stickers gql_categories=gql.data.site.product.categories.edges}}
         </figure>
         <ul class="productView-thumbnails"{{#gt product.images.length 5}} data-slick='{
                 "infinite": false,

--- a/templates/pages/product.html
+++ b/templates/pages/product.html
@@ -8,6 +8,26 @@ product:
         limit: {{theme_settings.productpage_related_products_count}}
     similar_by_views:
         limit: {{theme_settings.productpage_similar_by_views_count}}
+gql: "query productById($productId: Int!) {
+    site {
+        product(entityId: $productId) {
+            entityId
+            name
+            categories {
+                edges {
+                    node {
+                        entityId
+                        name
+                        path
+                        defaultImage {
+                            url(width: 256)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}"
 ---
 {{inject 'productId' product.id}}
 


### PR DESCRIPTION
Using a special purpose product category tree called "Stickers", site editors can add new sticker icons to PDP display by adding a new category and category image as a child category to the "Stickers" parent.
