### PR TITLE
Add category stickers to PLP product cards

### DIFF
--- a/config.json
+++ b/config.json
@@ -44,6 +44,7 @@
     "Firefox ESR"
   ],
   "settings": {
+    "stickers_root_id": 33,
     "hide_breadcrumbs": false,
     "hide_page_heading": false,
     "hide_category_page_heading": false,

--- a/templates/components/merch/card-stickers.html
+++ b/templates/components/merch/card-stickers.html
@@ -1,0 +1,22 @@
+{{!-- This example of server-side rendered card stickers relies on the GraphQL Front Matter attribute from
+the category.html template and the CSS styles added to the head block. --}}
+{{assignVar "product_has_stickers" 0}}
+{{#each category}}
+    {{assignVar "category_name" this}}
+    {{#each (get "children" (first ../gql.data.site.categoryTree))}}
+        {{#if (getVar "category_name") '===' this.name}}
+            {{!-- Create div container for all the sticker divs. --}}
+            {{#if (getVar "product_has_stickers") '!==' 1}}
+                <div class="product-stickers">
+                {{assignVar "product_has_stickers" 1}}
+            {{/if}}
+            <div class="product-stickers__sticker">
+                <img src="{{this.image.urlOriginal}}" alt="{{this.name}} icon" data-sticker-id="{{this.entityId}}">
+            </div>
+        {{/if}}
+    {{/each}}
+    {{!-- Add closing tag for div container. --}}
+    {{#if @last}}
+        {{#if (getVar "product_has_stickers")}}</div>{{/if}}
+    {{/if}}
+{{/each}}

--- a/templates/components/products/card.html
+++ b/templates/components/products/card.html
@@ -134,4 +134,8 @@
         </div>
         {{> components/products/bulk-discount-rates}}
     </div>
+    {{!-- Add custom stickers to product card --}}
+    {{#if gql.data.site.categoryTree}}
+        {{> components/merch/card-stickers}}
+    {{/if}}
 </article>

--- a/templates/components/products/grid.html
+++ b/templates/components/products/grid.html
@@ -1,7 +1,7 @@
 <ul class="productGrid">
     {{#each products}}
     <li class="product">
-            {{>components/products/card settings=../settings show_compare=../show_compare show_rating=../settings.show_product_rating theme_settings=../theme_settings customer=../customer event=../event position=(add @index 1)}}
+            {{>components/products/card settings=../settings show_compare=../show_compare show_rating=../settings.show_product_rating theme_settings=../theme_settings customer=../customer event=../event position=(add @index 1) gql=../gql}} {{!-- gql variable added to support card-stickers.html --}}
     </li>
     {{/each}}
 </ul>

--- a/templates/layout/base.html
+++ b/templates/layout/base.html
@@ -82,5 +82,6 @@
         <script async defer src="{{cdn 'assets/dist/theme-bundle.main.js' resourceHint='preload' as='script'}}" onload="onThemeBundleMain()"></script>
 
         {{{footer.scripts}}}
+        {{#block "page_bottom"}} {{/block}}
     </body>
 </html>

--- a/templates/pages/category.html
+++ b/templates/pages/category.html
@@ -3,6 +3,23 @@ category:
     shop_by_price: true
     products:
         limit: {{theme_settings.categorypage_products_per_page}}
+gql: "query StickerCategories {
+    site {
+        categoryTree(rootEntityId:33) {
+            ...CategoryFields
+            children {
+                ...CategoryFields
+            }
+        }
+    }
+}
+fragment CategoryFields on CategoryTreeItem {
+    name
+    entityId
+    image {
+        urlOriginal
+    }
+}"
 ---
 {{inject "categoryProductsPerPage" theme_settings.categorypage_products_per_page}}
 {{#partial "head"}}
@@ -53,5 +70,64 @@ category:
     </div>
 </div>
 
+{{/partial}}
+{{#partial "page_bottom"}}
+<style>
+article.card {
+    position: relative;
+}
+.product-stickers {
+    position: absolute;
+    right: 5px;
+    top: 5px;
+    display: flex;
+    flex-direction: row;
+}
+.product-stickers__sticker {
+    width: 32px;
+    height: auto;
+}
+</style>
+<script>
+    const StickerData = JSON.parse(`{{{json gql.data.site.categoryTree}}}`);
+    window.addEventListener('load', function() {
+        const productCards = document.querySelectorAll('article.card');
+        if (StickerData) {
+            productCards.forEach((product) => {
+                // Parse category from data-product-category attribute
+                const categories_text = product.getAttribute('data-product-category');
+                const categories = categories_text.split(',').map(item => item.trim());
+                let productHasStickers = false;
+                // check if product has any sticker categories
+                categories.forEach((category) => {
+                    StickerData[0].children.forEach((sticker) => {
+                        if (category === sticker.name) {
+                            // Create sticker container and append to product card element
+                            if (!productHasStickers) {
+                                const containerEl = document.createElement('div');
+                                containerEl.setAttribute('class', 'product-stickers');
+                                product.appendChild(containerEl);
+                                productHasStickers = true;
+                            }
+                            // Create the <div> element with class "product-stickers__sticker"
+                            const stickerEl = document.createElement('div');
+                            stickerEl.setAttribute('class', 'product-stickers__sticker');
+                            
+                            // Create the <img> element with its attributes
+                            const stickerImgEl = document.createElement('img');
+                            stickerImgEl.setAttribute('src', sticker.image.urlOriginal);
+                            stickerImgEl.setAttribute('alt', `${sticker.name} icon`);
+                            stickerImgEl.setAttribute('data-sticker-id', sticker.entityId);
+                            
+                            // Append the <img> element as a child of the <div> element
+                            stickerEl.appendChild(stickerImgEl);
+                            product.querySelector('div.product-stickers').appendChild(stickerEl);
+                        }
+                    })
+                });
+            });
+        }
+    });
+</script>
 {{/partial}}
 {{> layout/base}}

--- a/templates/pages/category.html
+++ b/templates/pages/category.html
@@ -29,6 +29,23 @@ fragment CategoryFields on CategoryTreeItem {
     {{#if pagination.category.next}}
         <link rel="next" href="{{pagination.category.next}}">
     {{/if}}
+
+    <style>
+        article.card {
+            position: relative;
+        }
+        .product-stickers {
+            position: absolute;
+            right: 5px;
+            top: 5px;
+            display: flex;
+            flex-direction: row;
+        }
+        .product-stickers__sticker {
+            width: 32px;
+            height: auto;
+        }
+    </style>
 {{/partial}}
 
 {{#partial "page"}}
@@ -70,64 +87,5 @@ fragment CategoryFields on CategoryTreeItem {
     </div>
 </div>
 
-{{/partial}}
-{{#partial "page_bottom"}}
-<style>
-article.card {
-    position: relative;
-}
-.product-stickers {
-    position: absolute;
-    right: 5px;
-    top: 5px;
-    display: flex;
-    flex-direction: row;
-}
-.product-stickers__sticker {
-    width: 32px;
-    height: auto;
-}
-</style>
-<script>
-    const StickerData = JSON.parse(`{{{json gql.data.site.categoryTree}}}`);
-    window.addEventListener('load', function() {
-        const productCards = document.querySelectorAll('article.card');
-        if (StickerData) {
-            productCards.forEach((product) => {
-                // Parse category from data-product-category attribute
-                const categories_text = product.getAttribute('data-product-category');
-                const categories = categories_text.split(',').map(item => item.trim());
-                let productHasStickers = false;
-                // check if product has any sticker categories
-                categories.forEach((category) => {
-                    StickerData[0].children.forEach((sticker) => {
-                        if (category === sticker.name) {
-                            // Create sticker container and append to product card element
-                            if (!productHasStickers) {
-                                const containerEl = document.createElement('div');
-                                containerEl.setAttribute('class', 'product-stickers');
-                                product.appendChild(containerEl);
-                                productHasStickers = true;
-                            }
-                            // Create the <div> element with class "product-stickers__sticker"
-                            const stickerEl = document.createElement('div');
-                            stickerEl.setAttribute('class', 'product-stickers__sticker');
-                            
-                            // Create the <img> element with its attributes
-                            const stickerImgEl = document.createElement('img');
-                            stickerImgEl.setAttribute('src', sticker.image.urlOriginal);
-                            stickerImgEl.setAttribute('alt', `${sticker.name} icon`);
-                            stickerImgEl.setAttribute('data-sticker-id', sticker.entityId);
-                            
-                            // Append the <img> element as a child of the <div> element
-                            stickerEl.appendChild(stickerImgEl);
-                            product.querySelector('div.product-stickers').appendChild(stickerEl);
-                        }
-                    })
-                });
-            });
-        }
-    });
-</script>
 {{/partial}}
 {{> layout/base}}


### PR DESCRIPTION
## User story

As a store admin, I want to create stickers/icons, which can be easily added to products for display on category pages.

### Solution

The core elements of the solution include:

- A "Sticker" root category which is treated as a static/constant and directly coupled with the theme, e.g. `"stickers_root_id": 33` in `config.json`. This root category is set to be not visible in the Control Panel.
- Store admins can create a stickers/icons by creating a new category under the Stickers root category and providing a category image (PNG with transparent background).
- Product cards on the PLP contain `category` template variable which includes any sticker icon categories added to a product.
- A `StickerCategories` Front Matter GraphQL query on the `category.html` provides all the sticker data needed to render icons on the PLP. 